### PR TITLE
“vulnerabilities-removed”

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1999,7 +1999,7 @@ node-pre-gyp@^0.6.36:
     request "2.81.0"
     rimraf "^2.6.1"
     semver "^5.3.0"
-    tar "^2.2.1"
+    tar "^4.4.2"
     tar-pack "^3.4.0"
 
 node-worker-pool@^3.0.2:
@@ -2726,12 +2726,12 @@ tar-pack@^3.4.0:
     once "^1.3.3"
     readable-stream "^2.1.4"
     rimraf "^2.5.1"
-    tar "^2.2.1"
+    tar "^4.4.2"
     uid-number "^0.0.6"
 
-tar@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-2.2.1.tgz#8e4d2a256c0e2185c6b18ad694aec968b83cb1d1"
+tar@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.2.tgz#8e4d2a256c0e2185c6b18ad694aec968b83cb1d1"
   dependencies:
     block-stream "*"
     fstream "^1.0.2"


### PR DESCRIPTION
Hi, I received GitHub alerts about security vulnerabilities, I changed them as recommended and made the PR:
"Remediation
Upgrade tar to version 4.4.2 or later. For example:
tar@^4.4.2:
  version "4.4.2" "
Cheers.